### PR TITLE
 Bug fixed on delete subscription features.

### DIFF
--- a/data_subscriptions/notifications/not_subscribable_notification_dispatcher.py
+++ b/data_subscriptions/notifications/not_subscribable_notification_dispatcher.py
@@ -46,7 +46,7 @@ class NotSubscribableNotifiationDispatcher:
 
     def send(self):
         email_dispatcher = EmailDispatcher(self.user["email"])
-        email_dispatcher(self._template_data)
+        email_dispatcher(self._template_data, "update")
 
     @property
     def dataset(self):


### PR DESCRIPTION
Passing activity type `update` parameter for the subscription delete email notification, which will dispatch the email with dataset update email template from the SendGrid. 