### PR TITLE
Error when activity type is not in the list - bug fixed

### DIFF
--- a/data_subscriptions/notifications/email_template.py
+++ b/data_subscriptions/notifications/email_template.py
@@ -30,7 +30,8 @@ class EmailTemplateData:
                 data["new_package"].append(new_dataset_item)
             else:
                 dataset_item = DatasetActivity(metadata, activities)()
-                data["packages"].append(dataset_item)
+                if dataset_item is not None:
+                    data["packages"].append(dataset_item)
         return data
 
     def activities_by_dataset(self):
@@ -59,9 +60,13 @@ class DatasetActivity:
         }
 
         for activity in self.activities:
-            if self.get_activity_type(activity) not in items["activities"]:
+            activity_msg = self.get_activity_type(activity)
+            if activity_msg and (activity_msg not in items["activities"]):
                 items["activities"].append(self.get_activity_type(activity))
-        return items
+        if items["activities"]:
+            return items
+        else:
+            return None
 
     def get_activity_type(self, activity):
         messages_for_activity_type = {
@@ -88,4 +93,7 @@ class DatasetActivity:
             activity["activity_type"] = new_activity_type
 
         if "activity_type" in activity:
-            return messages_for_activity_type[activity.get("activity_type")]
+            if activity.get("activity_type") in messages_for_activity_type.keys():
+                return messages_for_activity_type[activity.get("activity_type")]
+            else:
+                return False


### PR DESCRIPTION
https://gitlab.com/datopian/clients/national-grid/-/issues/321#note_398456613
## Issue
throwing error when there is no activity type on `messages_for_activity_type ` dict.  
```batchfile
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 385, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 648, in __protected_call__
    return self.run(*args, **kwargs)
  File "/code/data_subscriptions/worker/tasks.py", line 70, in dispatch_notifications
    BatchDispatcher()()
  File "/code/data_subscriptions/notifications/batch_dispatcher.py", line 27, in __call__
    dispatcher()
  File "/code/data_subscriptions/notifications/user_notification_dispatcher.py", line 32, in __call__
    self.prepare()
  File "/code/data_subscriptions/notifications/user_notification_dispatcher.py", line 48, in prepare
    self._template_data = email_template.template_data()
  File "/code/data_subscriptions/notifications/email_template.py", line 32, in template_data
    dataset_item = DatasetActivity(metadata, activities)()
  File "/code/data_subscriptions/notifications/email_template.py", line 62, in __call__
    if self.get_activity_type(activity) not in items["activities"]:
  File "/code/data_subscriptions/notifications/email_template.py", line 92, in get_activity_type
    return messages_for_activity_type[activity.get("activity_type")]
KeyError: 'new packageextra'
```


**Fixes**
-  don't add activity message if the activity type does not exist on message dictionary   