### PR TITLE
Session close on CKAN API call

### DIFF
--- a/data_subscriptions/notifications/ckan_metadata.py
+++ b/data_subscriptions/notifications/ckan_metadata.py
@@ -26,5 +26,6 @@ class CKANMetadata:
             except errors.NotFound:
                 url = f"action={self.action} id={item_id}"
                 logging.error(f"CKAN API NotFound error: {url}")
+            RemoteCKAN.close(self.api)
 
         return metadata

--- a/data_subscriptions/notifications/email_template.py
+++ b/data_subscriptions/notifications/email_template.py
@@ -86,6 +86,7 @@ class DatasetActivity:
             return messages_for_activity_type[activity_type]
 
         details = self.ckan_api.action.activity_detail_list(id=activity["id"])
+        RemoteCKAN.close(self.ckan_api)
 
         if len(details) >= 1:
             detail = details[0]


### PR DESCRIPTION
**Fixes for:** 
```
[2020-08-20 07:35:08,590: DEBUG/ForkPoolWorker-2] Resetting dropped connection: national-grid-dx-national-grid
[2020-08-20 07:35:08,611: DEBUG/ForkPoolWorker-2] http://national-grid-dx-national-grid:80 "POST /api/action/package_show HTTP/1.1" 200 2
539
```
We have resolved similar issue  for ` recently_changed_packages_activity_list`  with https://github.com/datopian/data-subscriptions/pull/6.  but  still some other `package_show`, `activity_detail` api have same issue. 

**Fixes**
- Closing the session after CKAN api call. 
