### PR TITLE
Time of activities pull should be the timestamp after the pulling process.

### DIFF
--- a/data_subscriptions/worker/dataset_activity_list.py
+++ b/data_subscriptions/worker/dataset_activity_list.py
@@ -15,8 +15,8 @@ class DatasetActivityList:
         self.load()
 
     def extract(self):
-        self.collected_at = dt.datetime.now()
         self.blob = LatestCKANActivity(start_time=self.start_time())()
+        self.collected_at = dt.datetime.now()
 
     def load(self):
         db.session.add(self.build_data_activity_list())


### PR DESCRIPTION
Since pulling activities can take significant amount of time, eg, we've seen 38s, the timestamp of 'collected_at' attribute should be captured once pulling activities has finished.