### PR TITLE
 Bug fixed for custom activity type message

### DIFF
--- a/data_subscriptions/notifications/email_template.py
+++ b/data_subscriptions/notifications/email_template.py
@@ -74,7 +74,7 @@ class DatasetActivity:
             activity["data"].get("body", {}).get("activity_type", False)
         )
         if custom_activity_type:
-            return self.get_message_for_activity([custom_activity_type])
+            return self.get_message_for_activity(custom_activity_type)
 
         activity_type_from_detail = self.get_activity_detail(activity["id"])
 

--- a/tests/notifications/test_user_notification_dispatcher.py
+++ b/tests/notifications/test_user_notification_dispatcher.py
@@ -74,6 +74,35 @@ def test_call_without_user(mocker, subject, db, subscription_data):
     subject.send.assert_not_called()
 
 
+def test_prepare_tempate_custom_activity(mocker, subject, db, subscription_data):
+    db.session.add(subscription_data)
+    db.session.commit()
+
+    activities = [{
+        "dataset_id": "42",
+        "activity": {
+            "object_id": "42",
+            "data": {
+                "action": "datastore_delete",
+                "body": {
+                    "resource_id": "xxx-xxx-xxx",
+                    "activity_type": "deleted resource"
+                }
+            },
+            "activity_type": "none"
+        }
+    }]
+    subject = UserNotificationDispatcher(
+        "user-id-1", activities, dt.datetime(2020, 1, 1)
+    )
+    subject.prepare()
+    dispatcher = mocker.patch(
+        "data_subscriptions.notifications.user_notification_dispatcher.EmailDispatcher"
+    )
+    subject.send()
+    assert len(subject.datasetUpdateMsgFilter(subject._template_data)) == 1
+    dispatcher.return_value.assert_called_once()
+
 def test_prepare_tempate_new_dataset_notification(
     mocker, subject, db, subscription_data
 ):


### PR DESCRIPTION
Related Issue: https://gitlab.com/datopian/clients/national-grid/-/issues/332#note_417071263
- Bug fixed on custom activity type message stream. 
- Also added test  for it. 
