### PR TITLE
Bug fixed on detail level activity message stream

### DIFF
--- a/data_subscriptions/notifications/email_template.py
+++ b/data_subscriptions/notifications/email_template.py
@@ -58,11 +58,10 @@ class DatasetActivity:
             "url": "%s/%s" % (pkg_url, self.dataset["name"]),
             "activities": [],
         }
-
         for activity in self.activities:
             activity_msg = self.get_activity_type(activity)
             if activity_msg and (activity_msg not in items["activities"]):
-                items["activities"].append(self.get_activity_type(activity))
+                items["activities"].append(activity_msg)
         if items["activities"]:
             return items
         else:
@@ -86,8 +85,18 @@ class DatasetActivity:
     def get_activity_detail(self, activity_id):
         details = self.ckan_api.action.activity_detail_list(id=activity_id)
         RemoteCKAN.close(self.ckan_api)
-        if len(details) >= 1:
-            detail = details[0]
+        
+        if details:
+            try:
+                # Filter recent activity sorted by 'last_modified'
+                detail = sorted(
+                    details, key=lambda i: i["data"].get("resource", i["data"].get("package"))[
+                        "last_modified"
+                    ] or "", reverse=True,
+                )[0]
+            except:
+                detail = details[0]
+
             object_type = detail["object_type"]
             activity_type = "%s %s" % (detail["activity_type"], object_type.lower())
             return activity_type


### PR DESCRIPTION
# Issue  Summary
https://github.com/datopian/data-subscriptions/blob/master/data_subscriptions/notifications/email_template.py#L89-L90

The creation of detail-level activities is inconsistent; sometimes most recent activity appears at the beginning of the array sometimes at last. Because of this inconsistent generating behavior, we are receiving incorrect messages. 
For eg.  When a user adds a new resource recently but the user receives an email notification with the  message `A file and/or the metadata for a file has been updated.`. But the user  expected to receive `A new file has been added.`

# Fixes
Before we filtered the first activity from the list and reference it as the most recent activity which didn't work as expected. Now activity with the recently modified package/resource will be referenced as the most recent one. 

