### PR TITLE
user agent added for ckan request and celery upgraded to 4.3.1

### DIFF
--- a/data_subscriptions/notifications/ckan_metadata.py
+++ b/data_subscriptions/notifications/ckan_metadata.py
@@ -15,9 +15,11 @@ class CKANMetadata:
     def __init__(self, action, entity_ids):
         self.action = action
         self.entity_ids = entity_ids
-        self.api = RemoteCKAN(CKAN_URL,
-                              apikey=CKAN_API_KEY,
-                              user_agent="data-subscription/latest (API call for CKAN activity pull)")
+        self.api = RemoteCKAN(
+            CKAN_URL,
+            apikey=CKAN_API_KEY,
+            user_agent="data-subscription/latest (API call for CKAN package metadata details)"
+        )
 
     def __call__(self):
         endpoint = getattr(self.api.action, self.action)

--- a/data_subscriptions/notifications/ckan_metadata.py
+++ b/data_subscriptions/notifications/ckan_metadata.py
@@ -15,7 +15,9 @@ class CKANMetadata:
     def __init__(self, action, entity_ids):
         self.action = action
         self.entity_ids = entity_ids
-        self.api = RemoteCKAN(CKAN_URL, apikey=CKAN_API_KEY)
+        self.api = RemoteCKAN(CKAN_URL,
+                              apikey=CKAN_API_KEY,
+                              user_agent="data-subscription/latest (API call for CKAN activity pull)")
 
     def __call__(self):
         endpoint = getattr(self.api.action, self.action)

--- a/data_subscriptions/notifications/email_template.py
+++ b/data_subscriptions/notifications/email_template.py
@@ -49,7 +49,10 @@ class DatasetActivity:
     def __init__(self, dataset, activities):
         self.dataset = dataset
         self.activities = activities
-        self.ckan_api = RemoteCKAN(CKAN_URL, apikey=CKAN_API_KEY)
+        self.ckan_api = RemoteCKAN(
+            CKAN_URL,
+            apikey=CKAN_API_KEY,
+            user_agent="data-subscription/latest (API call for CKAN activity pull)")
 
     def __call__(self):
         pkg_url = urljoin(FRONTEND_SITE_URL, self.dataset["organization"]["name"])

--- a/data_subscriptions/notifications/email_template.py
+++ b/data_subscriptions/notifications/email_template.py
@@ -52,7 +52,8 @@ class DatasetActivity:
         self.ckan_api = RemoteCKAN(
             CKAN_URL,
             apikey=CKAN_API_KEY,
-            user_agent="data-subscription/latest (API call for CKAN activity pull)")
+            user_agent="data-subscription/latest (API call for CKAN activity details)",
+        )
 
     def __call__(self):
         pkg_url = urljoin(FRONTEND_SITE_URL, self.dataset["organization"]["name"])

--- a/data_subscriptions/worker/latest_ckan_activity.py
+++ b/data_subscriptions/worker/latest_ckan_activity.py
@@ -16,7 +16,10 @@ class LatestCKANActivity:
         self.current_offset = 0
 
     def __call__(self):
-        api = RemoteCKAN(self.url)
+        api = RemoteCKAN(
+            self.url,
+            user_agent=
+            "data-subscription/latest (API call for CKAN activity pull)")
         self.activity_list = []
         while True:
             response = api.action.recently_changed_packages_activity_list(

--- a/data_subscriptions/worker/latest_ckan_activity.py
+++ b/data_subscriptions/worker/latest_ckan_activity.py
@@ -18,8 +18,8 @@ class LatestCKANActivity:
     def __call__(self):
         api = RemoteCKAN(
             self.url,
-            user_agent=
-            "data-subscription/latest (API call for CKAN activity pull)")
+            user_agent="data-subscription/latest (API call for CKAN recent activity pull)",
+        )
         self.activity_list = []
         while True:
             response = api.action.recently_changed_packages_activity_list(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-celery==4.3.0
+celery==4.3.1
 ckanapi==4.3
 flask-marshmallow==0.11.0 
 Flask-Migrate==2.5.3


### PR DESCRIPTION
- Custom User-agent add for all CKAN requests. 
- Celery upgraded to 4.3.1  for `ImportError: No module named 'vine'` issue. 